### PR TITLE
feat: add harness core profiles

### DIFF
--- a/docs/harness-core-and-profiles.md
+++ b/docs/harness-core-and-profiles.md
@@ -1,0 +1,49 @@
+# SoftOS Harness Core and Profiles
+
+This package separates reusable Harness Core policy from project-specific
+profiles.
+
+## Why
+
+Harness practices often mix universal delivery controls with local conventions
+such as repository labels, deploy commands, E2E runners, ticket systems, and
+communication tools. This split keeps the reusable policy open-source-safe while
+allowing each project to bind the core to its own workflow.
+
+## Core vs profile
+
+| Layer | Owns | Example |
+| --- | --- | --- |
+| Core | lifecycle, gates, reviewer contracts, evidence, progress, PR readiness concepts | R1-R5, empty open questions, dry-run first |
+| Profile | local tools, repo conventions, labels, deploy/E2E commands, mirror format, communication surfaces | repository labels, staging command, E2E runner |
+
+## Included profiles
+
+- `profiles/example-api-ticket/profile.json` — open-source-safe example profile.
+
+Projects should create their own private profiles for organization-specific
+repositories, labels, ticket systems, deploy commands, communication channels,
+and validation runners.
+
+## Validation
+
+```bash
+python3 scripts/harness/validate_profile.py --root . --json
+```
+
+The validator ensures:
+
+- required core files exist
+- core does not leak obvious project-private terms
+- profiles extend `policies/harness-core`
+- R1-R5 gates are declared
+- label discovery, communication ledger, and dry-run-first automation are present
+
+## Adoption path
+
+1. Copy or vendor the core policies.
+2. Start with `profiles/example-api-ticket/profile.json` as a template.
+3. Create a private project profile outside public source control if it contains
+   internal repository names, ticket-system URLs, deploy commands, or channel
+   references.
+4. Run the validator in CI or before publishing profile changes.

--- a/policies/harness-core/README.md
+++ b/policies/harness-core/README.md
@@ -1,0 +1,27 @@
+# SoftOS Harness Core
+
+SoftOS Harness Core is the reusable, project-neutral policy pack for ticket and
+change delivery. It defines the lifecycle, gates, evidence, review layers,
+progress visibility, communication, PR readiness, and dry-run-first automation
+without assuming any one company's repositories, labels, staging system, or chat
+tools.
+
+Use a project profile to bind this core to a real workspace. Profiles own repo
+labels, ticket systems, PR conventions, staging/deploy commands, E2E runners,
+repo-local planning formats, and communication surfaces.
+
+## Core files
+
+- `lifecycle.md` — generic intake-to-closeout flow.
+- `gates.md` — gate contracts and pass/fail rules.
+- `independent-review.md` — R1/R2/R3/R4/R5 reviewer layer.
+- `evidence.md` — evidence registry and stale-evidence rules.
+- `progress-and-communication.md` — progress/retry transparency and hypercommunication.
+- `pr-readiness.md` — branch/commit/PR readiness contract.
+- `automation.md` — dry-run-first automation model.
+
+## Design rule
+
+Core policies must stay free of project-specific names, links, credentials,
+private ticket keys, repository names, and environment URLs. Put those in
+`profiles/<profile-id>/profile.json` or profile documentation.

--- a/policies/harness-core/automation.md
+++ b/policies/harness-core/automation.md
@@ -1,0 +1,22 @@
+# Dry-Run-First Automation
+
+Automation should make the workflow repeatable without removing human gates.
+
+## Rule
+
+Every automation starts with `--dry-run` and produces local evidence before it
+mutates external systems.
+
+## First automation capabilities
+
+1. `bootstrap` — create initial artifacts.
+2. `gate-check` — validate active gates and stale evidence.
+3. `exact-revision-e2e` — validate the deployed revision for E2E.
+4. `pr-readiness` — validate branch/commit/PR metadata.
+5. `communication-ledger` — draft or publish state updates.
+
+## Write safety
+
+External writes require an explicit profile capability and user/tool
+authorization. If writes are unavailable, automation should produce exact drafts
+and target surfaces.

--- a/policies/harness-core/evidence.md
+++ b/policies/harness-core/evidence.md
@@ -1,0 +1,34 @@
+# Evidence Registry
+
+Every workflow should keep an evidence registry that names the current artifact
+for each gate and whether it is still valid for the current revision.
+
+## Minimum registry
+
+```md
+| Evidence | Status | Revision | Path/Link | Owner | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Spec | | | | | |
+| Plan | | | | | |
+| R1 | | | | | |
+| R2 | | | | | |
+| R3 | | | | | |
+| R4 | | | | | |
+| R5 | | | | | |
+| E2E | | | | | |
+| PR | | | | | |
+| Deploy | | | | | |
+| Communication | | | | | |
+```
+
+## Stale evidence rule
+
+Any change to the reviewed diff or deployed revision can invalidate downstream
+evidence. Profiles define which events invalidate which evidence, but by
+default:
+
+- spec change invalidates R1 and R2
+- plan change invalidates R2
+- code diff change invalidates R3 and R4
+- deployed revision change invalidates E2E and R4
+- PR head change invalidates exact-revision validation evidence

--- a/policies/harness-core/gates.md
+++ b/policies/harness-core/gates.md
@@ -1,0 +1,44 @@
+# Harness Core Gates
+
+## G0 — Intake Captured
+
+Pass when the source of truth, user-visible goal, suspected surfaces, and
+unknowns are recorded.
+
+## G1 — Research and Cluster Gate
+
+Pass when related tickets, PRs, specs, owner context, and overlapping code or
+contracts are classified as duplicate, superseding, dependency, semantic
+conflict, safe parallel, or unrelated.
+
+Fail when duplicate/superseding/semantic-conflict work remains unresolved.
+
+## G2 — Planning Gate
+
+Pass when the spec is internally consistent, scope is explicit, rollout and
+validation are planned, and `Open Questions` is empty or represented as `None`.
+
+Fail when any unresolved question remains in the spec.
+
+## G3 — Implementation Gate
+
+Pass when branch/write ownership is clear, generated artifacts are handled, and
+R3 code review has approved the diff for implementation changes.
+
+Fail when implementation is complete but no R3 artifact exists.
+
+## G4 — Validation Gate
+
+Pass when validation evidence proves the changed behavior and regressions, E2E
+is present or explicitly not applicable, environment/revision are documented,
+and R4 approves validation/deploy evidence.
+
+## G5 — PR / Commit Readiness Gate
+
+Pass when branch, commit, PR title/body, labels, reviewers, linked artifacts,
+and expected checks are validated by the active profile.
+
+## G6 — Closeout Gate
+
+Pass when PR/ticket/channel state reflects reality, follow-ups are linked,
+artifacts are complete, and lessons/memory are captured.

--- a/policies/harness-core/independent-review.md
+++ b/policies/harness-core/independent-review.md
@@ -1,0 +1,40 @@
+# Independent Review Layer
+
+Independent reviewers validate artifacts with fresh expert eyes. They must not
+inherit builder chat history or undocumented rationale.
+
+## R1 — Spec Review
+
+Approves only if the spec is implementation-ready, scope is explicit, related
+work is classified, validation is meaningful, and `Open Questions` is empty.
+
+Verdicts: `APPROVE_SPEC`, `REQUEST_SPEC_CHANGES`, `BLOCK_SPEC_SCOPE`.
+
+## R2 — Plan Review
+
+Approves only if the plan maps to the spec, write scopes are bounded, tests and
+rollout are scheduled, and no unresolved spec questions remain.
+
+Verdicts: `APPROVE_PLAN`, `REQUEST_PLAN_CHANGES`, `BLOCK_PLAN_UNCLEAR_SCOPE`.
+
+## R3 — Code Review
+
+Required for runtime, data, contract, generated-doc, or test diffs. Passing
+local tests or structural workflow verification is not a substitute.
+
+Verdicts: `APPROVE_CODE`, `REQUEST_CODE_CHANGES`, `BLOCK_CODE_SCOPE_OR_RISK`.
+
+## R4 — Validation / Deploy Review
+
+Approves only if validation evidence proves behavior for the correct revision or
+explicitly documents non-applicability with accepted compensating evidence.
+
+Verdicts: `APPROVE_VALIDATION`, `REQUEST_MORE_VALIDATION`, `BLOCK_ROLLOUT`.
+
+## R5 — PR / Commit Readiness Review
+
+Approves branch/commit/PR metadata before PR creation or ready-for-review.
+Profiles supply repo-specific labels, title conventions, reviewer rules, and
+expected checks.
+
+Verdicts: `APPROVE_PR_CREATE`, `REQUEST_PR_CHANGES`, `BLOCK_PR_PUBLISHING`.

--- a/policies/harness-core/lifecycle.md
+++ b/policies/harness-core/lifecycle.md
@@ -1,0 +1,48 @@
+# Harness Core Lifecycle
+
+## Purpose
+
+Provide a generic lifecycle for ambiguous, multi-step, review-sensitive work.
+The lifecycle is artifact-driven: each phase produces evidence that the next
+phase can consume without relying on chat history.
+
+## Phases
+
+0. Intake
+1. Triage
+2. Research
+3. Cluster / collision review
+4. Contract, dependency, and rollout analysis
+5. Planning and spec
+6. Approval gate
+7. Implementation
+8. Validation
+9. PR / commit readiness
+10. PR / review / communication
+11. Release / rollout
+12. Closeout and memory
+
+## Operating rules
+
+- Research precedes planning; planning precedes implementation.
+- Related work must be classified before implementation starts.
+- Draft specs may contain open questions; approved specs may not.
+- Reviews consume artifacts and evidence, not undocumented builder rationale.
+- Validation proves behavior, not only deploy success.
+- Communication surfaces should reflect current state.
+- Automation starts in dry-run mode until outputs are trusted.
+
+## Lifecycle outputs
+
+A profile may rename or route artifacts, but the semantic outputs should remain:
+
+- intake record
+- research pack
+- related-work cluster
+- contract/dependency matrix
+- implementation-ready spec
+- independent review artifacts
+- validation evidence
+- PR readiness pack
+- communication ledger
+- closeout/memory summary

--- a/policies/harness-core/pr-readiness.md
+++ b/policies/harness-core/pr-readiness.md
@@ -1,0 +1,44 @@
+# PR / Commit Readiness
+
+The PR/commit readiness gate prevents avoidable review and CI churn.
+
+## Required checks
+
+- branch is scoped to the work item and is not the base branch
+- commit list is reviewable and intentional
+- PR title follows the profile's title lint convention
+- PR body is complete without chat history
+- linked ticket/spec/evidence are present
+- labels are discovered from the target repository/profile, not guessed
+- reviewers/owners are identified or explicitly deferred
+- expected checks are known
+- PR stays draft until required gates pass
+
+## Readiness pack
+
+```md
+## Branch / Commit
+- Target repo:
+- Base branch:
+- Feature branch:
+- Commit message:
+- Commit SHA(s):
+
+## PR Metadata
+- Title:
+- Draft or ready:
+- Labels discovered:
+- Labels to apply:
+- Reviewers/owners:
+- Linked work item:
+- Spec/evidence links:
+
+## Expected Checks
+- Title lint:
+- Unit/lint/coverage:
+- Docs/contract:
+- Profile-specific checks:
+
+## Verdict
+- APPROVE_PR_CREATE / REQUEST_PR_CHANGES / BLOCK_PR_PUBLISHING
+```

--- a/policies/harness-core/progress-and-communication.md
+++ b/policies/harness-core/progress-and-communication.md
@@ -1,0 +1,38 @@
+# Progress, Retry, and Hypercommunication
+
+## Progress updates
+
+Long-running processes should be observable while they run. Do not hide retry
+loops or repeated polling until final closeout.
+
+```md
+Progress update:
+- Phase:
+- Completed:
+- Current step:
+- Retry/repeat:
+- Reason:
+- Continuing with:
+- Blocked only if:
+```
+
+Continue normal non-destructive retries without confirmation. Pause for real
+approval gates, destructive actions, security/credential risk, unusual cost or
+rate-limit risk, merge/deploy approval, or when no safe alternate path remains.
+
+## Hypercommunication
+
+Meaningful state changes should be reflected in the surfaces stakeholders use.
+Profiles define the concrete surfaces, but the core events are:
+
+- phase changes
+- blockers
+- open questions blocking or cleared
+- R1/R2/R3/R4/R5 verdicts
+- implementation complete / not-ready reasons
+- validation passed/failed/rerun
+- ready for review / merge / deploy
+- closeout and follow-ups
+
+If direct posting is unavailable, draft exact text and record the intended
+surface in the communication ledger.

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -1,0 +1,19 @@
+# SoftOS Harness Profiles
+
+Profiles bind the generic Harness Core to a specific organization, repository
+set, delivery workflow, and toolchain.
+
+A profile owns:
+
+- ticket systems and work item key patterns
+- repository mirror format
+- labels and PR conventions
+- staging/deploy/E2E strategy
+- communication surfaces
+- expected CI/check names
+- reviewer/owner discovery rules
+- redaction and privacy rules
+
+Core policies must remain project-neutral. Profiles may include project-specific
+conventions, but should avoid secrets and private links unless the profile is
+kept private/local.

--- a/profiles/example-api-ticket/README.md
+++ b/profiles/example-api-ticket/README.md
@@ -1,0 +1,4 @@
+# Example API Ticket Profile
+
+This is a generic example profile safe for open-source documentation. It is not
+bound to any private organization.

--- a/profiles/example-api-ticket/profile.json
+++ b/profiles/example-api-ticket/profile.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "harness-profile/v1",
+  "profile_id": "example-api-ticket",
+  "display_name": "Example API Ticket Delivery",
+  "extends": "policies/harness-core",
+  "visibility": "open-source-example",
+  "description": "Generic API ticket profile demonstrating how projects bind Harness Core to local conventions.",
+  "work_item": {
+    "systems": ["issue-tracker"],
+    "key_patterns": ["PROJ-[0-9]+"],
+    "required_links": ["work item", "spec", "PR"]
+  },
+  "repo_mirror": {
+    "enabled": true,
+    "path_template": ".planning/{ticket}/spec.md",
+    "format": "project-native"
+  },
+  "pull_request": {
+    "title_pattern": "<type>: <ticket> - <summary>",
+    "required_body_sections": ["Summary", "Work Item", "Planning", "Validation", "Risks"],
+    "label_discovery": "query_target_repo",
+    "required_labels": ["automation-assisted"],
+    "forbidden_manual_labels": ["do not merge", "security", "autorelease:*"],
+    "default_state": "draft_until_gates_pass"
+  },
+  "reviews": {
+    "required_gates": ["R1", "R2", "R3", "R4", "R5"]
+  },
+  "validation": {
+    "e2e_default": "profile-defined",
+    "exact_revision_required": true,
+    "non_applicability_requires_reason": true
+  },
+  "communication": {
+    "surfaces": ["PR", "work item", "owner thread", "planning artifact", "evidence registry"],
+    "ledger_required": true
+  },
+  "automation": {
+    "dry_run_first": true,
+    "external_writes_default": "draft_only"
+  }
+}

--- a/scripts/harness/validate_profile.py
+++ b/scripts/harness/validate_profile.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Validate SoftOS Harness Core + profile separation.
+
+This is intentionally stdlib-only so it can run before project dependencies are
+installed. It validates structure and catches obvious leakage of project-private
+terms into the reusable core policy pack.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_CORE_FILES = [
+    "README.md",
+    "lifecycle.md",
+    "gates.md",
+    "independent-review.md",
+    "evidence.md",
+    "progress-and-communication.md",
+    "pr-readiness.md",
+    "automation.md",
+]
+
+REQUIRED_PROFILE_KEYS = [
+    "schema_version",
+    "profile_id",
+    "extends",
+    "work_item",
+    "repo_mirror",
+    "pull_request",
+    "reviews",
+    "validation",
+    "communication",
+    "automation",
+]
+
+REQUIRED_GATES = {"R1", "R2", "R3", "R4", "R5"}
+
+# These are allowed in profiles but should not appear in reusable core docs.
+CORE_FORBIDDEN_TERMS = [
+    "gametime",
+    "gametimesf",
+    "mobileapi",
+    "seeds-database",
+    "NUA-",
+    "BE-14825",
+    "go.postman.co/workspace",
+]
+
+
+def load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except Exception as exc:  # pragma: no cover - user-facing CLI guard
+        raise SystemExit(f"invalid JSON in {path}: {exc}") from exc
+
+
+def validate_core(root: Path) -> list[str]:
+    errors: list[str] = []
+    core = root / "policies" / "harness-core"
+    if not core.is_dir():
+        return [f"missing core directory: {core}"]
+    for name in REQUIRED_CORE_FILES:
+        path = core / name
+        if not path.is_file():
+            errors.append(f"missing core policy: {path}")
+            continue
+        text = path.read_text(errors="replace")
+        lowered = text.lower()
+        for term in CORE_FORBIDDEN_TERMS:
+            if term.lower() in lowered:
+                errors.append(f"core policy leaks profile-specific term {term!r}: {path}")
+    return errors
+
+
+def discover_profiles(root: Path) -> list[str]:
+    profiles_dir = root / "profiles"
+    if not profiles_dir.is_dir():
+        return []
+    return sorted(
+        path.parent.name
+        for path in profiles_dir.glob("*/profile.json")
+        if path.is_file()
+    )
+
+
+def validate_profile(root: Path, profile_id: str) -> list[str]:
+    errors: list[str] = []
+    profile_path = root / "profiles" / profile_id / "profile.json"
+    if not profile_path.is_file():
+        return [f"missing profile: {profile_path}"]
+    profile = load_json(profile_path)
+    for key in REQUIRED_PROFILE_KEYS:
+        if key not in profile:
+            errors.append(f"profile {profile_id} missing key: {key}")
+    if profile.get("schema_version") != "harness-profile/v1":
+        errors.append(f"profile {profile_id} has unsupported schema_version: {profile.get('schema_version')}")
+    extends = profile.get("extends")
+    if extends != "policies/harness-core":
+        errors.append(f"profile {profile_id} must extend policies/harness-core, got {extends!r}")
+    gates = set(profile.get("reviews", {}).get("required_gates", []))
+    missing = REQUIRED_GATES - gates
+    if missing:
+        errors.append(f"profile {profile_id} missing required gates: {sorted(missing)}")
+    pr = profile.get("pull_request", {})
+    if not pr.get("label_discovery") and not pr.get("label_discovery_command"):
+        errors.append(f"profile {profile_id} must define label discovery")
+    automation = profile.get("automation", {})
+    if automation.get("dry_run_first") is not True:
+        errors.append(f"profile {profile_id} must set automation.dry_run_first=true")
+    communication = profile.get("communication", {})
+    if communication.get("ledger_required") is not True:
+        errors.append(f"profile {profile_id} must require a communication ledger")
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=".", help="SoftOS workspace root")
+    parser.add_argument("--profile", action="append", default=[], help="Profile id to validate")
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    profiles = args.profile or discover_profiles(root)
+    errors = validate_core(root)
+    if not profiles:
+        errors.append(f"no profiles found under {root / 'profiles'}")
+    for profile_id in profiles:
+        errors.extend(validate_profile(root, profile_id))
+
+    result = {
+        "status": "ok" if not errors else "failed",
+        "root": str(root),
+        "profiles": profiles,
+        "errors": errors,
+    }
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        if errors:
+            print("Harness core/profile validation failed:")
+            for error in errors:
+                print(f"- {error}")
+        else:
+            print("Harness core/profile validation passed")
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/specs/features/softos-harness-core-and-profiles.spec.md
+++ b/specs/features/softos-harness-core-and-profiles.spec.md
@@ -1,0 +1,52 @@
+---
+id: softos-harness-core-and-profiles
+status: draft
+owner: softos-harness
+---
+
+# SoftOS Harness Core and Profiles
+
+## Summary
+
+Separate reusable Harness Core policies from project-specific profiles so the
+pattern can be adopted across projects without hardcoding private conventions.
+
+## Problem
+
+Delivery harnesses often combine generic gates with local details such as label
+names, deploy flows, E2E commands, ticket systems, and communication surfaces.
+That makes reuse difficult and risks leaking private project context.
+
+## Goals
+
+- Define project-neutral core policies.
+- Define a profile contract for project-specific conventions.
+- Provide a generic open-source-safe example profile.
+- Provide a stdlib-only validator for core/profile structure.
+- Keep external writes dry-run-first unless a profile explicitly enables them.
+
+## Non-Goals
+
+- Do not include private repository names, ticket links, channel links,
+  credentials, or organization-specific deploy commands in the core package.
+- Do not require every project to use the same ticket system, PR labels, E2E
+  runner, or communication tool.
+
+## Slices
+
+1. `harness-core-policy-pack`
+2. `harness-profile-contract`
+3. `example-api-ticket-profile`
+4. `harness-profile-validator`
+5. `opensource-adoption-docs`
+
+## Validation Plan
+
+- Run `python3 scripts/harness/validate_profile.py --root . --json`.
+- Confirm core policies have no obvious project-private terms.
+- Confirm the example profile loads and declares required gates.
+- Confirm profile automation is dry-run-first.
+
+## Open Questions
+
+None


### PR DESCRIPTION
## Summary
- Add a project-neutral SoftOS Harness Core policy pack.
- Add an open-source-safe example API ticket profile.
- Add a stdlib-only profile validator for core/profile separation.

## Why
This lets SoftOS workflows reuse core gates while keeping project-specific labels, deploys, E2E runners, and communication surfaces in profiles/adapters.

## Included
- `policies/harness-core/*`
- `profiles/example-api-ticket/*`
- `scripts/harness/validate_profile.py`
- `docs/harness-core-and-profiles.md`
- `specs/features/softos-harness-core-and-profiles.spec.md`

## Validation
- `scripts/harness/validate_profile.py --root /Users/john.espitia/Projects/gametime-sdd-soft-os --json` → `status: ok`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPYCACHEPREFIX=/private/tmp/softos-harness-oss-pycache python3 -m py_compile /Users/john.espitia/Projects/gametime-sdd-soft-os/scripts/harness/validate_profile.py`
- `git -C /Users/john.espitia/Projects/gametime-sdd-soft-os diff --cached --check`
- Private-term grep check over extracted public files returned no results.

## Notes
- Project-specific/private profiles are intentionally not included.
- The unrelated local file `specs/features/gametime-softos-smoke.spec.md` was left out of this PR.
