### PR TITLE
chore(bmad): enforce multi-agent ownership handoff and gates

### DIFF
--- a/.agents/skills/bmad-agent-router/SKILL.md
+++ b/.agents/skills/bmad-agent-router/SKILL.md
@@ -95,6 +95,22 @@ python3 ./flow stack ps
 
 Treat "container up + app down" as not ready; run runtime-specific readiness checks before closing.
 
+### 7) Multi-agent execution contract (when requested)
+
+When the user explicitly requests multi-agent execution:
+
+1. Define disjoint slices by explicit write ownership.
+2. Assign one agent per slice.
+3. Require per-agent handoff artifacts with evidence.
+4. Enforce gate progression:
+   - `G2` before coding
+   - `G3` after implementation diff artifact
+   - `G4` after validation evidence
+   - `G5` before PR/promotion
+   - `G6` at closeout
+5. If ownership overlap appears, re-slice before continuing.
+6. Do not close multi-agent execution without handoff artifacts for every slice.
+
 ## Rules
 
 - Prefer `flow workflow ...` as the primary BMAD entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,44 @@ Usa el skill `workspace/skills-discover` cuando necesites buscar skills en tessl
 - Do not modify files outside active spec `targets` unless the spec is updated first.
 - Do not mark work complete without relevant `flow ci` evidence.
 
+## BMAD multi-agent contract
+
+### 1) Role model
+
+- `orchestrator`: owns intake/plan/routing, slice definition, gate verification, and promote-readiness decisions.
+- `implementation agents`: execute slices with explicit write ownership.
+- `verification agent`: validates evidence and regression risk without expanding functional scope.
+
+### 2) Ownership rules
+
+- Each agent must receive explicit write ownership by file paths/patterns before execution starts.
+- Ownership overlap between agents in the same wave is prohibited.
+- Shared files (`specs/**`, release manifests, workflow YAML) remain under `orchestrator` ownership unless a slice explicitly grants an exception.
+
+### 3) Handoff contract
+
+Every handoff must include:
+
+- completed scope
+- modified files
+- commands/tests executed
+- pending risks/blockers
+- next expected gate
+
+### 4) Gate contract
+
+Required gates:
+
+- `G0` intake captured
+- `G1` research/cluster resolved
+- `G2` planning/spec consistent
+- `G3` implementation review artifact
+- `G4` validation evidence
+- `G5` PR/commit readiness
+- `G6` closeout evidence/state consistency
+
+Rule: if a gate is not satisfied, do not advance to the next one.
+
 ## SoftOS operating playbooks
 
 For any AI agent working in this workspace, the following local playbooks are the preferred source of operational guidance:


### PR DESCRIPTION
## Summary
Add an OSS-compatible BMAD multi-agent contract to root policy and router skill.

## Motivation
Multi-agent execution needs explicit contracts for role separation, write ownership, handoff artifacts, and non-skippable gates to reduce overlap, drift, and unclear closeout decisions.

## Scope
- Update `AGENTS.md` with a new **BMAD multi-agent contract** section:
  - role model
  - ownership rules
  - handoff contract
  - gate contract (G0-G6, no-advance rule)
- Update `.agents/skills/bmad-agent-router/SKILL.md` with **Multi-agent execution contract (when requested)**:
  - disjoint slice ownership
  - one agent per slice
  - mandatory handoff artifacts
  - gate progression requirements
  - overlap re-slice rule
  - no closeout without handoff artifacts per slice

## Validation
- `python3 scripts/ci/validate_docs_i18n.py --audit-all`
- `python3 scripts/harness/validate_profile.py --root . --json`
- Reviewed final diff for only the two requested files.

## Backward compatibility / Risks
- Backward compatible for existing single-agent flows.
- No runtime behavior changes; policy/skill hardening only.
- Main risk is stricter process expectations for multi-agent requests, which is intended and explicit.
