### PR TITLE
feat: add usage cost harness

### DIFF
--- a/docs/es/harness-core-and-profiles.es.md
+++ b/docs/es/harness-core-and-profiles.es.md
@@ -41,6 +41,14 @@ Los proyectos deberian crear perfiles privados para repositorios especificos,
 labels, sistemas de tickets, comandos de deploy, canales de comunicacion y
 runners de validacion.
 
+
+## Usage and Cost Harness
+
+El Harness Core incluye una politica de telemetria de uso/costo en
+`policies/harness-core/usage-and-cost.md`. Los profiles pueden activar
+`usage_telemetry` para emitir checkpoints en progress updates y resumen final,
+marcando cada valor como `exact`, `provider_reconciled` o `estimated`.
+
 ## Validacion
 
 ```bash

--- a/docs/harness-core-and-profiles.md
+++ b/docs/harness-core-and-profiles.md
@@ -16,6 +16,7 @@ profiles.
 - Stdlib-only validator at `scripts/harness/validate_profile.py`.
 - Feature source spec at
   `specs/features/softos-harness-core-and-profiles.spec.md`.
+- Usage and Cost Harness policy at `policies/harness-core/usage-and-cost.md`.
 
 ## Why
 
@@ -28,7 +29,7 @@ allowing each project to bind the core to its own workflow.
 
 | Layer | Owns | Example |
 | --- | --- | --- |
-| Core | lifecycle, gates, reviewer contracts, evidence, progress, PR readiness concepts | R1-R5, empty open questions, dry-run first |
+| Core | lifecycle, gates, reviewer contracts, evidence, progress, PR readiness concepts, usage/cost telemetry | R1-R5, empty open questions, dry-run first, usage checkpoints |
 | Profile | local tools, repo conventions, labels, deploy/E2E commands, mirror format, communication surfaces | repository labels, staging command, E2E runner |
 
 ## Included profiles
@@ -51,7 +52,7 @@ The validator ensures:
 - core does not leak obvious project-private terms
 - profiles extend `policies/harness-core`
 - R1-R5 gates are declared
-- label discovery, communication ledger, and dry-run-first automation are present
+- label discovery, communication ledger, usage telemetry, and dry-run-first automation are present
 
 ## Adoption path
 

--- a/policies/harness-core/README.md
+++ b/policies/harness-core/README.md
@@ -19,6 +19,7 @@ repo-local planning formats, and communication surfaces.
 - `progress-and-communication.md` — progress/retry transparency and hypercommunication.
 - `pr-readiness.md` — branch/commit/PR readiness contract.
 - `automation.md` — dry-run-first automation model.
+- `usage-and-cost.md` — token/cost telemetry, budget gates, and final reports.
 
 ## Design rule
 

--- a/policies/harness-core/usage-and-cost.md
+++ b/policies/harness-core/usage-and-cost.md
@@ -1,0 +1,88 @@
+# Usage and Cost Harness
+
+The Usage and Cost Harness makes agent work observable from a spend and token
+consumption perspective. It is a reporting and budget-control layer for any
+profile that runs model, tool, or automation work.
+
+## Signal classes
+
+Every usage value must declare one of these modes:
+
+- `exact` — captured directly from the request/response or tool runtime that
+  produced the usage.
+- `provider_reconciled` — read from a provider usage/cost API, dashboard, or
+  invoice-aligned report for a time window, project, API key, user, or model.
+- `estimated` — computed from local token counting, transcript size, elapsed
+  runtime, or manual input because exact usage is not exposed locally.
+
+Never mix these modes without labeling them. A final report may contain all
+three, but it must show which totals are exact, provider-reconciled, and
+estimated.
+
+## Checkpoints
+
+Profiles should emit usage checkpoints at meaningful boundaries:
+
+- process/session start
+- phase or gate start/end
+- long-running loop progress update
+- retry/rerun
+- agent handoff
+- external tool run
+- validation/deploy run
+- closeout
+
+A checkpoint should include:
+
+```md
+Usage update:
+- Window:
+- Phase/gate:
+- Agent/process:
+- Mode: exact / provider_reconciled / estimated
+- Requests:
+- Input tokens:
+- Cached input tokens:
+- Output tokens:
+- Tool calls/sessions:
+- Cost:
+- Budget used:
+- Confidence:
+- Notes/caveats:
+```
+
+## Budget gates
+
+Usage telemetry is advisory unless a profile marks it blocking.
+
+Recommended default behavior:
+
+- warn when estimated or reconciled spend reaches the profile warning threshold
+- pause before continuing when a hard cap is reached
+- continue without confirmation for low-cost, non-destructive retries below the
+  warning threshold
+- require explicit approval for unusually expensive research, repeated failures,
+  or external tools with separate billable line items
+
+## Final report
+
+Closeout must include a final usage report when the profile enables this
+harness. The report should break down consumption by:
+
+- ticket/work item
+- phase/gate
+- agent/process
+- model/provider
+- tool or external service
+- repo/slice when available
+- mode (`exact`, `provider_reconciled`, `estimated`)
+
+The final report must include caveats for provider lag, missing per-turn usage,
+or estimates that cannot be reconciled.
+
+## Evidence and privacy
+
+Usage evidence must not contain secrets, raw API keys, private prompts,
+customer data, or sensitive chat transcripts. Store identifiers as aliases or
+redacted IDs. If provider APIs are queried, record the query window and grouping
+but not credentials.

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -25,3 +25,5 @@ A profile owns:
 Core policies must remain project-neutral. Profiles may include
 project-specific conventions, but should avoid secrets and private links unless
 the profile is kept private/local.
+
+Usage/cost telemetry is enabled through `usage_telemetry` in each profile. The reporting contract requires progress-update checkpoints and closeout summaries, with every value labeled as `exact`, `provider_reconciled`, or `estimated`.

--- a/profiles/es/README.es.md
+++ b/profiles/es/README.es.md
@@ -25,3 +25,5 @@ Un profile define:
 Las politicas core deben permanecer neutrales al proyecto. Los profiles pueden
 incluir convenciones especificas, pero deben evitar secretos y enlaces privados
 salvo que el profile se mantenga privado/local.
+
+La telemetria de uso/costo se activa con `usage_telemetry` en cada profile. El contrato exige checkpoints en progress updates y resumen de closeout, marcando cada valor como `exact`, `provider_reconciled` o `estimated`.

--- a/profiles/example-api-ticket/README.es.md
+++ b/profiles/example-api-ticket/README.es.md
@@ -7,3 +7,10 @@ No esta ligado a ninguna organizacion privada.
 
 Usalo como plantilla para crear tu profile privado con labels locales,
 nomenclatura de repositorios, keys de tickets y comandos de automatizacion.
+
+## Telemetria de uso/costo
+
+Este profile de ejemplo activa checkpoints de uso/costo durante trabajo largo,
+reintentos, handoffs de agentes, herramientas externas, validacion/deploy y
+closeout. Cada valor debe marcarse como `exact`, `provider_reconciled` o
+`estimated`.

--- a/profiles/example-api-ticket/README.md
+++ b/profiles/example-api-ticket/README.md
@@ -7,3 +7,17 @@ bound to any private organization.
 
 Use it as a template to create your own private profile with local labels,
 repository naming, ticket keys, and automation commands.
+
+## Usage and cost telemetry
+
+This example profile enables usage/cost checkpoints during long-running work,
+retries, agent handoffs, external tool runs, validation/deploy runs, and
+closeout. Reports must mark every value as `exact`, `provider_reconciled`, or
+`estimated`.
+
+```bash
+python3 scripts/harness/usage_report.py checkpoint --ticket PROJ-123 --profile example-api-ticket --phase G1 --agent research_agent --mode estimated --note "research checkpoint"
+python3 scripts/harness/usage_report.py summary --file docs/evidence/proj-123-usage-and-cost.json
+# Optional provider reconciliation when an admin API key is configured:
+python3 scripts/harness/usage_report.py openai-snapshot --ticket PROJ-123 --profile example-api-ticket --start-time <unix-seconds> --group-by model --group-by project_id
+```

--- a/profiles/example-api-ticket/profile.json
+++ b/profiles/example-api-ticket/profile.json
@@ -6,9 +6,17 @@
   "visibility": "open-source-example",
   "description": "Generic API ticket profile demonstrating how projects bind Harness Core to local conventions.",
   "work_item": {
-    "systems": ["issue-tracker"],
-    "key_patterns": ["PROJ-[0-9]+"],
-    "required_links": ["work item", "spec", "PR"]
+    "systems": [
+      "issue-tracker"
+    ],
+    "key_patterns": [
+      "PROJ-[0-9]+"
+    ],
+    "required_links": [
+      "work item",
+      "spec",
+      "PR"
+    ]
   },
   "repo_mirror": {
     "enabled": true,
@@ -17,14 +25,32 @@
   },
   "pull_request": {
     "title_pattern": "<type>: <ticket> - <summary>",
-    "required_body_sections": ["Summary", "Work Item", "Planning", "Validation", "Risks"],
+    "required_body_sections": [
+      "Summary",
+      "Work Item",
+      "Planning",
+      "Validation",
+      "Risks"
+    ],
     "label_discovery": "query_target_repo",
-    "required_labels": ["automation-assisted"],
-    "forbidden_manual_labels": ["do not merge", "security", "autorelease:*"],
+    "required_labels": [
+      "automation-assisted"
+    ],
+    "forbidden_manual_labels": [
+      "do not merge",
+      "security",
+      "autorelease:*"
+    ],
     "default_state": "draft_until_gates_pass"
   },
   "reviews": {
-    "required_gates": ["R1", "R2", "R3", "R4", "R5"]
+    "required_gates": [
+      "R1",
+      "R2",
+      "R3",
+      "R4",
+      "R5"
+    ]
   },
   "validation": {
     "e2e_default": "profile-defined",
@@ -32,11 +58,103 @@
     "non_applicability_requires_reason": true
   },
   "communication": {
-    "surfaces": ["PR", "work item", "owner thread", "planning artifact", "evidence registry"],
+    "surfaces": [
+      "PR",
+      "work item",
+      "owner thread",
+      "planning artifact",
+      "evidence registry"
+    ],
     "ledger_required": true
   },
   "automation": {
     "dry_run_first": true,
     "external_writes_default": "draft_only"
+  },
+  "usage_telemetry": {
+    "enabled": true,
+    "report_in_progress_updates": true,
+    "report_in_closeout": true,
+    "modes": [
+      "exact",
+      "provider_reconciled",
+      "estimated"
+    ],
+    "default_mode_when_unavailable": "estimated",
+    "checkpoint_triggers": [
+      "process_start",
+      "phase_start",
+      "phase_end",
+      "long_running_progress_update",
+      "retry_or_rerun",
+      "agent_handoff",
+      "external_tool_run",
+      "validation_or_deploy_run",
+      "closeout"
+    ],
+    "dimensions": [
+      "ticket",
+      "phase",
+      "gate",
+      "agent",
+      "process",
+      "model",
+      "tool",
+      "repo",
+      "mode"
+    ],
+    "progress_update_fields": [
+      "window",
+      "phase/gate",
+      "agent/process",
+      "mode",
+      "requests",
+      "input tokens",
+      "cached input tokens",
+      "output tokens",
+      "tool calls/sessions",
+      "cost",
+      "budget used",
+      "confidence",
+      "notes/caveats"
+    ],
+    "final_report_required": true,
+    "final_report_breakdown": [
+      "phase",
+      "gate",
+      "agent",
+      "model",
+      "tool",
+      "repo",
+      "mode"
+    ],
+    "budget": {
+      "enabled": true,
+      "currency": "usd",
+      "limit_source": "ticket/process override or operator config",
+      "default_limit": null,
+      "warn_at_percent": 70,
+      "pause_at_percent": 100,
+      "pause_requires_user_approval": true
+    },
+    "evidence": {
+      "default_json_path_template": "docs/evidence/{ticket}-usage-and-cost.json",
+      "default_markdown_path_template": "docs/evidence/{ticket}-usage-and-cost.md",
+      "include_in_closeout": true,
+      "redact_credentials": true,
+      "do_not_store_raw_prompts_by_default": true
+    },
+    "reconciliation": {
+      "provider_cost_is_financial_source_of_truth": true,
+      "provider_usage_may_lag": true,
+      "record_query_window": true,
+      "record_grouping_dimensions": true
+    },
+    "data_sources": [
+      "response usage object when available",
+      "provider usage/cost API when configured",
+      "local estimator/manual checkpoint when exact usage is unavailable"
+    ],
+    "reporting_command": "python3 scripts/harness/usage_report.py checkpoint --ticket PROJ-123 --profile example-api-ticket ..."
   }
 }

--- a/scripts/harness/usage_report.py
+++ b/scripts/harness/usage_report.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Create SoftOS Harness usage/cost checkpoints and closeout summaries.
+
+This helper is intentionally stdlib-only. It does not call provider APIs or
+store credentials. It records exact, provider-reconciled, or estimated usage
+that the operator/agent provides, and can compute an estimated USD cost when
+per-million-token rates are passed on the command line.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+VALID_MODES = {"exact", "provider_reconciled", "estimated"}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def slug(value: str) -> str:
+    return "".join(ch.lower() if ch.isalnum() else "-" for ch in value).strip("-") or "usage"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        raise SystemExit(f"missing file: {path}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"invalid JSON in {path}: {exc}") from exc
+
+
+def load_profile(root: Path, profile_id: str) -> dict[str, Any]:
+    path = root / "profiles" / profile_id / "profile.json"
+    profile = load_json(path)
+    usage = profile.get("usage_telemetry")
+    if not isinstance(usage, dict) or usage.get("enabled") is not True:
+        raise SystemExit(f"profile {profile_id} does not enable usage_telemetry")
+    return profile
+
+
+def default_report_path(root: Path, profile: dict[str, Any], ticket: str) -> Path:
+    template = (
+        profile.get("usage_telemetry", {})
+        .get("evidence", {})
+        .get("default_json_path_template", "docs/evidence/{ticket}-usage-and-cost.json")
+    )
+    return root / template.format(ticket=slug(ticket))
+
+
+def money(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"${value:.6f}"
+
+
+def compute_cost(args: argparse.Namespace) -> float | None:
+    explicit = getattr(args, "cost_usd", None)
+    if explicit is not None:
+        return explicit
+    rate_fields = [
+        args.input_rate_per_mtok,
+        args.cached_input_rate_per_mtok,
+        args.output_rate_per_mtok,
+        args.tool_cost_usd,
+    ]
+    if all(value is None for value in rate_fields):
+        return None
+    input_tokens = args.input_tokens or 0
+    cached_tokens = args.cached_input_tokens or 0
+    uncached_input = max(input_tokens - cached_tokens, 0)
+    output_tokens = args.output_tokens or 0
+    total = 0.0
+    if args.input_rate_per_mtok is not None:
+        total += uncached_input * args.input_rate_per_mtok / 1_000_000
+    if args.cached_input_rate_per_mtok is not None:
+        total += cached_tokens * args.cached_input_rate_per_mtok / 1_000_000
+    elif args.input_rate_per_mtok is not None:
+        # Conservative fallback when no cached rate is provided.
+        total += cached_tokens * args.input_rate_per_mtok / 1_000_000
+    if args.output_rate_per_mtok is not None:
+        total += output_tokens * args.output_rate_per_mtok / 1_000_000
+    if args.tool_cost_usd is not None:
+        total += args.tool_cost_usd
+    return total
+
+
+def empty_report(ticket: str, profile_id: str, root: Path) -> dict[str, Any]:
+    now = utc_now()
+    return {
+        "schema_version": "usage-and-cost-report/v1",
+        "ticket": ticket,
+        "profile_id": profile_id,
+        "root": str(root),
+        "created_at": now,
+        "updated_at": now,
+        "checkpoints": [],
+        "notes": [
+            "Each checkpoint must declare mode: exact, provider_reconciled, or estimated.",
+            "Provider-reconciled cost is the financial source of truth when available; provider data may lag.",
+        ],
+    }
+
+
+def load_or_create_report(path: Path, ticket: str, profile_id: str, root: Path) -> dict[str, Any]:
+    if path.exists():
+        return load_json(path)
+    return empty_report(ticket=ticket, profile_id=profile_id, root=root)
+
+
+def add_checkpoint(args: argparse.Namespace) -> int:
+    root = Path(args.root).resolve()
+    profile = load_profile(root, args.profile)
+    path = Path(args.output).resolve() if args.output else default_report_path(root, profile, args.ticket)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    report = load_or_create_report(path, args.ticket, args.profile, root)
+
+    if args.mode not in VALID_MODES:
+        raise SystemExit(f"invalid mode {args.mode!r}; expected one of {sorted(VALID_MODES)}")
+
+    cost = compute_cost(args)
+    checkpoint = {
+        "timestamp": utc_now(),
+        "window": args.window,
+        "phase": args.phase,
+        "gate": args.gate,
+        "agent": args.agent,
+        "process": args.process,
+        "repo": args.repo,
+        "model": args.model,
+        "tool": args.tool,
+        "mode": args.mode,
+        "requests": args.requests or 0,
+        "input_tokens": args.input_tokens or 0,
+        "cached_input_tokens": args.cached_input_tokens or 0,
+        "output_tokens": args.output_tokens or 0,
+        "tool_calls": args.tool_calls or 0,
+        "tool_sessions": args.tool_sessions or 0,
+        "cost_usd": cost,
+        "confidence": args.confidence,
+        "source": args.source,
+        "note": args.note,
+    }
+    report.setdefault("checkpoints", []).append(checkpoint)
+    report["updated_at"] = utc_now()
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(format_checkpoint(checkpoint, path))
+    return 0
+
+
+def totals_by(checkpoints: list[dict[str, Any]], key: str) -> dict[str, dict[str, float]]:
+    result: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    for item in checkpoints:
+        bucket = str(item.get(key) or "unknown")
+        result[bucket]["requests"] += item.get("requests") or 0
+        result[bucket]["input_tokens"] += item.get("input_tokens") or 0
+        result[bucket]["cached_input_tokens"] += item.get("cached_input_tokens") or 0
+        result[bucket]["output_tokens"] += item.get("output_tokens") or 0
+        result[bucket]["tool_calls"] += item.get("tool_calls") or 0
+        result[bucket]["tool_sessions"] += item.get("tool_sessions") or 0
+        if item.get("cost_usd") is not None:
+            result[bucket]["cost_usd"] += item.get("cost_usd") or 0
+    return result
+
+
+def total(checkpoints: list[dict[str, Any]], field: str) -> float:
+    return sum((item.get(field) or 0) for item in checkpoints)
+
+
+def total_cost(checkpoints: list[dict[str, Any]]) -> float | None:
+    values = [item.get("cost_usd") for item in checkpoints if item.get("cost_usd") is not None]
+    if not values:
+        return None
+    return float(sum(values))
+
+
+def format_checkpoint(checkpoint: dict[str, Any], path: Path) -> str:
+    return "\n".join([
+        "Usage update:",
+        f"- Report: {path}",
+        f"- Window: {checkpoint.get('window') or 'n/a'}",
+        f"- Phase/gate: {checkpoint.get('phase') or 'n/a'} / {checkpoint.get('gate') or 'n/a'}",
+        f"- Agent/process: {checkpoint.get('agent') or 'n/a'} / {checkpoint.get('process') or 'n/a'}",
+        f"- Mode: {checkpoint.get('mode')}",
+        f"- Requests: {checkpoint.get('requests', 0)}",
+        f"- Input tokens: {checkpoint.get('input_tokens', 0)}",
+        f"- Cached input tokens: {checkpoint.get('cached_input_tokens', 0)}",
+        f"- Output tokens: {checkpoint.get('output_tokens', 0)}",
+        f"- Tool calls/sessions: {checkpoint.get('tool_calls', 0)} / {checkpoint.get('tool_sessions', 0)}",
+        f"- Cost: {money(checkpoint.get('cost_usd'))}",
+        f"- Confidence: {checkpoint.get('confidence') or 'n/a'}",
+        f"- Notes/caveats: {checkpoint.get('note') or 'n/a'}",
+    ])
+
+
+def markdown_summary(report: dict[str, Any]) -> str:
+    checkpoints = report.get("checkpoints", [])
+    cost = total_cost(checkpoints)
+    lines = [
+        "# Usage & Cost Report",
+        "",
+        f"- Ticket: {report.get('ticket')}",
+        f"- Profile: {report.get('profile_id')}",
+        f"- Updated: {report.get('updated_at')}",
+        f"- Checkpoints: {len(checkpoints)}",
+        f"- Requests: {int(total(checkpoints, 'requests'))}",
+        f"- Input tokens: {int(total(checkpoints, 'input_tokens'))}",
+        f"- Cached input tokens: {int(total(checkpoints, 'cached_input_tokens'))}",
+        f"- Output tokens: {int(total(checkpoints, 'output_tokens'))}",
+        f"- Tool calls: {int(total(checkpoints, 'tool_calls'))}",
+        f"- Tool sessions: {int(total(checkpoints, 'tool_sessions'))}",
+        f"- Cost: {money(cost)}",
+        "",
+        "## Breakdown by mode",
+        "",
+    ]
+    for mode, values in sorted(totals_by(checkpoints, "mode").items()):
+        lines.append(
+            f"- {mode}: requests={int(values['requests'])}, input={int(values['input_tokens'])}, "
+            f"cached={int(values['cached_input_tokens'])}, output={int(values['output_tokens'])}, "
+            f"cost={money(values.get('cost_usd'))}"
+        )
+    for key in ["phase", "agent", "model", "tool", "repo"]:
+        lines.extend(["", f"## Breakdown by {key}", ""])
+        for bucket, values in sorted(totals_by(checkpoints, key).items()):
+            lines.append(
+                f"- {bucket}: requests={int(values['requests'])}, input={int(values['input_tokens'])}, "
+                f"cached={int(values['cached_input_tokens'])}, output={int(values['output_tokens'])}, "
+                f"cost={money(values.get('cost_usd'))}"
+            )
+    lines.extend(["", "## Caveats", ""])
+    notes = report.get("notes") or []
+    for note in notes:
+        lines.append(f"- {note}")
+    if any(item.get("mode") == "estimated" for item in checkpoints):
+        lines.append("- Some checkpoints are estimated because exact per-turn usage was unavailable locally.")
+    if any(item.get("mode") == "provider_reconciled" for item in checkpoints):
+        lines.append("- Provider-reconciled values may lag but should be treated as the financial source of truth when available.")
+    return "\n".join(lines) + "\n"
+
+
+def openai_get(base_url: str, path: str, api_key: str, params: dict[str, Any]) -> dict[str, Any]:
+    query = urllib.parse.urlencode({k: v for k, v in params.items() if v is not None}, doseq=True)
+    url = base_url.rstrip("/") + path + (f"?{query}" if query else "")
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {api_key}"})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as response:  # noqa: S310 - operator-provided API URL/key
+            payload = response.read().decode("utf-8")
+    except Exception as exc:  # pragma: no cover - network/operator environment
+        raise SystemExit(f"provider snapshot request failed for {path}: {exc}") from exc
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"provider snapshot returned invalid JSON for {path}: {exc}") from exc
+
+
+def parse_provider_totals(payload: dict[str, Any]) -> dict[str, float]:
+    totals: dict[str, float] = defaultdict(float)
+
+    def visit(node: Any) -> None:
+        if isinstance(node, dict):
+            if "input_tokens" in node:
+                totals["input_tokens"] += node.get("input_tokens") or 0
+            if "input_cached_tokens" in node:
+                totals["cached_input_tokens"] += node.get("input_cached_tokens") or 0
+            if "cached_input_tokens" in node:
+                totals["cached_input_tokens"] += node.get("cached_input_tokens") or 0
+            if "output_tokens" in node:
+                totals["output_tokens"] += node.get("output_tokens") or 0
+            if "num_model_requests" in node:
+                totals["requests"] += node.get("num_model_requests") or 0
+            amount = node.get("amount")
+            if isinstance(amount, dict) and amount.get("currency") in (None, "usd"):
+                totals["cost_usd"] += amount.get("value") or 0
+            for value in node.values():
+                visit(value)
+        elif isinstance(node, list):
+            for item in node:
+                visit(item)
+
+    visit(payload)
+    return totals
+
+
+def openai_snapshot(args: argparse.Namespace) -> int:
+    root = Path(args.root).resolve()
+    profile = load_profile(root, args.profile)
+    path = Path(args.output).resolve() if args.output else default_report_path(root, profile, args.ticket)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    api_key = os.environ.get(args.api_key_env)
+    if not api_key:
+        raise SystemExit(f"missing provider API key env var: {args.api_key_env}")
+
+    group_by = args.group_by or []
+    common_params: dict[str, Any] = {
+        "start_time": args.start_time,
+        "end_time": args.end_time,
+        "bucket_width": args.bucket_width,
+    }
+    if group_by:
+        common_params["group_by"] = group_by
+
+    usage_payload = openai_get(args.base_url, args.usage_path, api_key, common_params)
+    costs_payload = openai_get(args.base_url, args.costs_path, api_key, common_params)
+    usage_totals = parse_provider_totals(usage_payload)
+    cost_totals = parse_provider_totals(costs_payload)
+
+    report = load_or_create_report(path, args.ticket, args.profile, root)
+    checkpoint = {
+        "timestamp": utc_now(),
+        "window": f"{args.start_time}..{args.end_time or 'now'}",
+        "phase": args.phase or "provider_reconciliation",
+        "gate": args.gate,
+        "agent": args.agent or "usage_harness",
+        "process": "provider_snapshot",
+        "repo": args.repo,
+        "model": args.model,
+        "tool": "provider_usage_cost_api",
+        "mode": "provider_reconciled",
+        "requests": int(usage_totals.get("requests") or 0),
+        "input_tokens": int(usage_totals.get("input_tokens") or 0),
+        "cached_input_tokens": int(usage_totals.get("cached_input_tokens") or 0),
+        "output_tokens": int(usage_totals.get("output_tokens") or 0),
+        "tool_calls": 0,
+        "tool_sessions": 0,
+        "cost_usd": cost_totals.get("cost_usd") if "cost_usd" in cost_totals else None,
+        "confidence": "provider_reconciled",
+        "source": "OpenAI organization usage/costs API",
+        "note": args.note or "Provider usage/cost APIs may lag and may not map perfectly to a single ticket unless isolated by project/API key/window.",
+    }
+    report.setdefault("checkpoints", []).append(checkpoint)
+    snapshots = report.setdefault("provider_snapshots", [])
+    snapshot: dict[str, Any] = {
+        "timestamp": checkpoint["timestamp"],
+        "provider": "openai",
+        "query": {
+            "base_url": args.base_url,
+            "usage_path": args.usage_path,
+            "costs_path": args.costs_path,
+            "start_time": args.start_time,
+            "end_time": args.end_time,
+            "bucket_width": args.bucket_width,
+            "group_by": group_by,
+            "api_key_env": args.api_key_env,
+        },
+        "usage_totals": dict(usage_totals),
+        "cost_totals": dict(cost_totals),
+    }
+    if args.store_raw:
+        snapshot["raw_usage_response"] = usage_payload
+        snapshot["raw_costs_response"] = costs_payload
+    snapshots.append(snapshot)
+    report["updated_at"] = utc_now()
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(format_checkpoint(checkpoint, path))
+    return 0
+
+
+def summary(args: argparse.Namespace) -> int:
+    path = Path(args.file).resolve()
+    report = load_json(path)
+    markdown = markdown_summary(report)
+    if args.markdown_output:
+        out = Path(args.markdown_output).resolve()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(markdown)
+        print(f"wrote {out}")
+    else:
+        print(markdown, end="")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    cp = sub.add_parser("checkpoint", help="Append a usage/cost checkpoint")
+    cp.add_argument("--root", default=".")
+    cp.add_argument("--profile", required=True)
+    cp.add_argument("--ticket", required=True)
+    cp.add_argument("--output")
+    cp.add_argument("--window")
+    cp.add_argument("--phase")
+    cp.add_argument("--gate")
+    cp.add_argument("--agent")
+    cp.add_argument("--process")
+    cp.add_argument("--repo")
+    cp.add_argument("--model")
+    cp.add_argument("--tool")
+    cp.add_argument("--mode", choices=sorted(VALID_MODES), required=True)
+    cp.add_argument("--requests", type=int, default=0)
+    cp.add_argument("--input-tokens", type=int, default=0)
+    cp.add_argument("--cached-input-tokens", type=int, default=0)
+    cp.add_argument("--output-tokens", type=int, default=0)
+    cp.add_argument("--tool-calls", type=int, default=0)
+    cp.add_argument("--tool-sessions", type=int, default=0)
+    cp.add_argument("--cost-usd", type=float)
+    cp.add_argument("--input-rate-per-mtok", type=float)
+    cp.add_argument("--cached-input-rate-per-mtok", type=float)
+    cp.add_argument("--output-rate-per-mtok", type=float)
+    cp.add_argument("--tool-cost-usd", type=float)
+    cp.add_argument("--confidence")
+    cp.add_argument("--source")
+    cp.add_argument("--note")
+    cp.set_defaults(func=add_checkpoint)
+
+    sm = sub.add_parser("summary", help="Print or write a markdown summary")
+    sm.add_argument("--file", required=True)
+    sm.add_argument("--markdown-output")
+    sm.set_defaults(func=summary)
+
+    op = sub.add_parser("openai-snapshot", help="Append a provider-reconciled OpenAI Usage/Costs snapshot")
+    op.add_argument("--root", default=".")
+    op.add_argument("--profile", required=True)
+    op.add_argument("--ticket", required=True)
+    op.add_argument("--output")
+    op.add_argument("--start-time", type=int, required=True, help="Unix seconds, inclusive")
+    op.add_argument("--end-time", type=int, help="Unix seconds, exclusive/endpoint-defined")
+    op.add_argument("--bucket-width", default="1d")
+    op.add_argument("--group-by", action="append", default=[])
+    op.add_argument("--base-url", default="https://api.openai.com")
+    op.add_argument("--usage-path", default="/v1/organization/usage/completions")
+    op.add_argument("--costs-path", default="/v1/organization/costs")
+    op.add_argument("--api-key-env", default="OPENAI_ADMIN_KEY")
+    op.add_argument("--phase")
+    op.add_argument("--gate")
+    op.add_argument("--agent")
+    op.add_argument("--repo")
+    op.add_argument("--model")
+    op.add_argument("--note")
+    op.add_argument("--store-raw", action="store_true", help="Store raw provider responses; avoid if they contain sensitive metadata")
+    op.set_defaults(func=openai_snapshot)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/harness/validate_profile.py
+++ b/scripts/harness/validate_profile.py
@@ -42,13 +42,12 @@ REQUIRED_GATES = {"R1", "R2", "R3", "R4", "R5"}
 
 # These are allowed in profiles but should not appear in reusable core docs.
 CORE_FORBIDDEN_TERMS = [
-    "gametime",
-    "gametimesf",
-    "mobileapi",
-    "seeds-database",
-    "NUA-",
-    "BE-14825",
-    "go.postman.co/workspace",
+    "company-internal",
+    "internal-repo",
+    "private-ticket-",
+    "private-slack",
+    "private-postman-workspace",
+    "customer-data-example",
 ]
 
 

--- a/scripts/harness/validate_profile.py
+++ b/scripts/harness/validate_profile.py
@@ -21,6 +21,7 @@ REQUIRED_CORE_FILES = [
     "progress-and-communication.md",
     "pr-readiness.md",
     "automation.md",
+    "usage-and-cost.md",
 ]
 
 REQUIRED_PROFILE_KEYS = [
@@ -34,6 +35,7 @@ REQUIRED_PROFILE_KEYS = [
     "validation",
     "communication",
     "automation",
+    "usage_telemetry",
 ]
 
 REQUIRED_GATES = {"R1", "R2", "R3", "R4", "R5"}
@@ -86,6 +88,39 @@ def discover_profiles(root: Path) -> list[str]:
     )
 
 
+def validate_usage_telemetry(profile_id: str, profile: dict) -> list[str]:
+    errors: list[str] = []
+    usage = profile.get("usage_telemetry", {})
+    if usage.get("enabled") is not True:
+        errors.append(f"profile {profile_id} must set usage_telemetry.enabled=true")
+    if usage.get("report_in_progress_updates") is not True:
+        errors.append(f"profile {profile_id} must report usage in progress updates")
+    if usage.get("report_in_closeout") is not True:
+        errors.append(f"profile {profile_id} must report usage in closeout")
+    modes = set(usage.get("modes", []))
+    missing_modes = {"exact", "provider_reconciled", "estimated"} - modes
+    if missing_modes:
+        errors.append(f"profile {profile_id} usage_telemetry missing modes: {sorted(missing_modes)}")
+    for key in ["checkpoint_triggers", "dimensions", "progress_update_fields", "final_report_breakdown"]:
+        if not usage.get(key):
+            errors.append(f"profile {profile_id} usage_telemetry.{key} must be non-empty")
+    if usage.get("final_report_required") is not True:
+        errors.append(f"profile {profile_id} must require a final usage/cost report")
+    budget = usage.get("budget", {})
+    if budget.get("enabled") is not True:
+        errors.append(f"profile {profile_id} usage_telemetry.budget.enabled must be true")
+    if budget.get("warn_at_percent") is None or budget.get("pause_at_percent") is None:
+        errors.append(f"profile {profile_id} usage_telemetry.budget must define warn_at_percent and pause_at_percent")
+    evidence = usage.get("evidence", {})
+    for key in ["default_json_path_template", "default_markdown_path_template"]:
+        if not evidence.get(key):
+            errors.append(f"profile {profile_id} usage_telemetry.evidence.{key} must be set")
+    reconciliation = usage.get("reconciliation", {})
+    if reconciliation.get("provider_cost_is_financial_source_of_truth") is not True:
+        errors.append(f"profile {profile_id} must identify provider-reconciled cost as financial source of truth")
+    return errors
+
+
 def validate_profile(root: Path, profile_id: str) -> list[str]:
     errors: list[str] = []
     profile_path = root / "profiles" / profile_id / "profile.json"
@@ -113,6 +148,7 @@ def validate_profile(root: Path, profile_id: str) -> list[str]:
     communication = profile.get("communication", {})
     if communication.get("ledger_required") is not True:
         errors.append(f"profile {profile_id} must require a communication ledger")
+    errors.extend(validate_usage_telemetry(profile_id, profile))
     return errors
 
 

--- a/specs/features/softos-usage-cost-harness.spec.md
+++ b/specs/features/softos-usage-cost-harness.spec.md
@@ -1,0 +1,133 @@
+---
+schema_version: 3
+name: "SoftOS usage and cost harness"
+description: "Agregar telemetria de uso/costo para checkpoints de agentes, estimaciones, reconciliacion de proveedor y reportes de closeout."
+status: approved
+owner: platform
+single_slice_reason: "usage/cost harness is a bounded governance and reporting layer over existing Harness Core profiles"
+multi_domain: false
+phases: []
+depends_on:
+  - specs/000-foundation/spec-as-source-operating-model.spec.md
+  - specs/000-foundation/spec-driven-delivery-and-infrastructure.spec.md
+required_runtimes: []
+required_services: []
+required_capabilities: []
+stack_projects: []
+stack_services: []
+stack_capabilities: []
+targets:
+  - ../../workspace.config.json
+  - ../../policies/harness-core/README.md
+  - ../../policies/harness-core/usage-and-cost.md
+  - ../../profiles/README.md
+  - ../../profiles/es/README.es.md
+  - ../../profiles/example-api-ticket/README.md
+  - ../../profiles/example-api-ticket/README.es.md
+  - ../../profiles/example-api-ticket/profile.json
+  - ../../scripts/harness/validate_profile.py
+  - ../../scripts/harness/usage_report.py
+  - ../../docs/harness-core-and-profiles.md
+  - ../../docs/es/harness-core-and-profiles.es.md
+  - ../../specs/features/softos-usage-cost-harness.spec.md
+---
+
+# SoftOS Usage and Cost Harness
+
+## Objetivo
+
+Agregar un Harness reusable de uso/costo para que SoftOS pueda reportar consumo
+de modelos, herramientas y automatizaciones durante progress updates y closeout.
+
+## Contexto actual
+
+- Harness Core ya define gates, evidencia, hipercomunicacion y PR readiness.
+- Los workflows largos pueden consumir tokens, llamadas de herramientas, sesiones
+  de runtime y otros recursos billables sin visibilidad incremental.
+- Algunas ejecuciones exponen uso exacto por request, otras solo pueden
+  reconciliarse por proveedor, y otras requieren estimacion local.
+
+## Governing Decision
+
+- Todo valor de uso/costo debe declarar un modo: `exact`,
+  `provider_reconciled` o `estimated`.
+- El costo reconciliado por proveedor es la fuente financiera de verdad cuando
+  existe, pero puede tener lag y puede no mapear perfecto a un ticket salvo que
+  se aisle por proyecto, API key, usuario o ventana.
+- El helper no guarda credenciales, prompts crudos, transcripts privados ni
+  datos sensibles.
+- El budget gate es reportable por defecto y solo bloqueante cuando el profile u
+  operador define umbrales.
+
+## Executable Surface Inventory
+
+| Superficie | Cambio obligatorio | Prohibido |
+|---|---|---|
+| `policies/harness-core/usage-and-cost.md` | Definir signal classes, checkpoints, budget gates, final report y privacidad. | Mencionar repos, tickets o canales privados. |
+| `profiles/example-api-ticket/profile.json` | Declarar `usage_telemetry` reusable y open-source-safe. | Asumir un proveedor obligatorio. |
+| `scripts/harness/usage_report.py` | Crear checkpoints, summaries y snapshot opcional de proveedor sin dependencias externas. | Guardar credenciales o requerir red para el modo local. |
+| `scripts/harness/validate_profile.py` | Exigir estructura minima de `usage_telemetry`. | Codificar reglas de una organizacion privada. |
+| Docs/i18n | Documentar adopcion y comandos. | Prometer exactitud cuando el runtime no la expone. |
+
+## Algorithm
+
+1. Un profile activa `usage_telemetry.enabled=true` y define triggers, fields,
+   budget, evidence paths y reconciliacion.
+2. Durante el proceso, el agente u operador ejecuta `usage_report.py checkpoint`
+   con los datos disponibles y el modo correcto.
+3. En progress updates largos se copia el bloque `Usage update` generado.
+4. Al cierre, `usage_report.py summary` genera el reporte Markdown.
+5. Si hay credenciales admin y una ventana apropiada, `openai-snapshot` puede
+   agregar un checkpoint `provider_reconciled` sin guardar credenciales.
+
+## Stop Conditions
+
+- Un profile sin `usage_telemetry` no pasa `validate_profile.py`.
+- Un checkpoint sin modo valido debe fallar.
+- Un reporte no debe guardar credenciales, prompts crudos ni datos sensibles.
+- Si se alcanza el umbral de pausa de budget, el profile debe pedir aprobacion
+  antes de continuar.
+
+## Slice Breakdown
+
+```yaml
+- name: usage-cost-harness
+  targets:
+    - ../../workspace.config.json
+    - ../../policies/harness-core/README.md
+    - ../../policies/harness-core/usage-and-cost.md
+    - ../../profiles/README.md
+    - ../../profiles/es/README.es.md
+    - ../../profiles/example-api-ticket/README.md
+    - ../../profiles/example-api-ticket/README.es.md
+    - ../../profiles/example-api-ticket/profile.json
+    - ../../scripts/harness/validate_profile.py
+    - ../../scripts/harness/usage_report.py
+    - ../../docs/harness-core-and-profiles.md
+    - ../../docs/es/harness-core-and-profiles.es.md
+    - ../../specs/features/softos-usage-cost-harness.spec.md
+  hot_area: harness governance and usage reporting
+  depends_on: []
+  slice_mode: governance
+  surface_policy: required
+  minimum_valid_completion: usage telemetry validates, checkpoint smoke works, and docs are mirrored
+  validated_noop_allowed: false
+  acceptable_evidence:
+    - validate_profile JSON status ok
+    - py_compile for validator and usage_report
+    - docs i18n validation passed
+    - usage_report checkpoint and summary smoke output
+```
+
+## Validation Plan
+
+- Run `python3 scripts/harness/validate_profile.py --root . --json`.
+- Run `python3 -m py_compile scripts/harness/validate_profile.py scripts/harness/usage_report.py`.
+- Run `python3 scripts/ci/validate_docs_i18n.py`.
+- Run a local smoke checkpoint and summary using `scripts/harness/usage_report.py` with `/private/tmp` outputs.
+- Confirm the new core/example/docs files do not contain project-private links,
+  credentials, or organization-specific commands.
+
+## Open Questions
+
+None

--- a/workspace.config.json
+++ b/workspace.config.json
@@ -45,14 +45,19 @@
         "workspace.skills.json",
         "workspace.stack.json",
         "tessl.json",
-        "Makefile"
+        "Makefile",
+        "policies",
+        "profiles"
       ],
       "default_targets": [
         "../../specs/**/*.spec.md",
         "../../docs/**/*.md",
         "../../flow",
         "../../workspace.config.json",
-        "../../workspace.stack.json"
+        "../../workspace.stack.json",
+        "../../policies/**/*.md",
+        "../../profiles/**/*.md",
+        "../../profiles/**/*.json"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- Add a reusable Usage and Cost Harness policy to Harness Core.
- Add `usage_telemetry` to the open-source `example-api-ticket` profile.
- Add a stdlib-only `scripts/harness/usage_report.py` helper for checkpoints, summaries, and optional OpenAI Usage/Costs snapshots.
- Extend profile validation to require usage telemetry and register `policies`/`profiles` as governed target roots.

## Why
Long-running agent workflows should show model/tool/runtime usage during progress updates and final closeout. The harness separates `exact`, `provider_reconciled`, and `estimated` usage so teams do not confuse local estimates with provider/billing truth.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 scripts/harness/validate_profile.py --root /Users/john.espitia/Projects/gametime-sdd-soft-os --json`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPYCACHEPREFIX=/private/tmp/softos-oss-usage-pycache python3 -m py_compile scripts/harness/validate_profile.py scripts/harness/usage_report.py`
- `python3 scripts/ci/validate_docs_i18n.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/Users/john.espitia/Projects/gametime-sdd-soft-os/.venv/lib/python3.12/site-packages python3 ./flow ci spec softos-usage-cost-harness --json`
- `usage_report.py checkpoint` + `usage_report.py summary` smoke using `/private/tmp/oss-usage-and-cost.*`
- Private-term grep over new core/example/docs/script/spec surfaces returned no results.

## Notes
- This PR is open-source-safe and does not include the private Gametime profile overlay.
- Optional provider reconciliation requires an operator-provided admin API key env var; credentials are not stored.
- The unrelated local file `specs/features/gametime-softos-smoke.spec.md` was intentionally left out.
