### PR TITLE
chore(flow): enforce workspace-only host execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Usa el skill `workspace/skills-discover` cuando necesites buscar skills en tessl
 - When a root spec includes `targets` that point into a submodule, read the root spec first and then descend into the corresponding submodule `AGENTS.md` before editing code.
 - Treat `.flow/**` as operational state only. It helps with orchestration, but it never overrides `specs/**`.
 - Run workspace-managed toolchains from the devcontainer by default. Use `python3 ./flow workspace exec -- <cmd>` or `scripts/workspace_exec.sh <cmd>` from host.
+- Host-level `flow` execution is blocked by default (`FLOW_FORCE_WORKSPACE_EXEC=1`). Run via `flow workspace exec`/`scripts/workspace_exec.sh`; only `flow stack ...` and explicit `flow workspace exec -- ...` are allowed on host.
 - Run repo runtime commands in the repo service, not in `workspace`. Use `python3 ./flow repo exec <repo> -- <cmd>` for PHPUnit, Composer, pnpm, pytest, Go test, etc.
 - If the command validates a slice worktree, use `python3 ./flow repo exec <repo> --workdir <worktree> -- <cmd>` so module resolution, autoload, caches and relative paths come from the worktree under test.
 - If a slice is governance, enforcement, minimal-change, or verification-only, do not infer missing expansion work. Follow the spec's `surface_policy`, `minimum_valid_completion`, `validated_noop_allowed`, and `acceptable_evidence`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# SoftOS Claude Code Context
+
+Use this file as the operational contract for Claude Code in this workspace.
+
+## Command harness (mandatory)
+
+- `specs/**` is the source of truth.
+- `.flow/**` is operational state only.
+- Run workspace-managed commands in devcontainer via `python3 ./flow workspace exec -- <cmd>` or `scripts/workspace_exec.sh <cmd>`.
+- Host `flow` execution is blocked by default (`FLOW_FORCE_WORKSPACE_EXEC=1`) unless using `flow stack ...` or explicit `flow workspace exec -- ...`.
+- Keep host execution only for `flow stack ...` and explicit `flow workspace exec -- ...`.
+- Run repo runtime commands in repo services with `python3 ./flow repo exec <repo> -- <cmd>`.
+
+## Required context loading
+
+- `AGENTS.md`
+- `CURSOR.md`
+- `OPENCODE.md`
+- `.cursor/rules/softos.mdc`
+- `.cursor/rules/softos-enforcement.mdc`

--- a/CURSOR.md
+++ b/CURSOR.md
@@ -9,6 +9,7 @@ Use this file when Cursor CLI does not load `.cursor/rules/**` automatically.
 - Read the active spec and `workspace.config.json` before non-trivial edits.
 - Resolve repo/runtime from spec `targets` and workspace routing.
 - Run workspace-managed commands from the devcontainer by default with `python3 ./flow workspace exec -- <cmd>` or `scripts/workspace_exec.sh <cmd>`.
+- `flow` en host está en modo estricto por defecto (`FLOW_FORCE_WORKSPACE_EXEC=1`): bloquea comandos no-`stack` fuera de `workspace` y exige `flow workspace exec -- ...`.
 - Run repo runtime commands in the repo service with `python3 ./flow repo exec <repo> -- <cmd>`. Do not run PHPUnit, Composer, pnpm, pytest or Go test in `workspace` when the repo has its own service.
 - When validating a slice worktree, use `python3 ./flow repo exec <repo> --workdir <worktree> -- <cmd>` so the runner resolves files from the slice under test, not from the base checkout.
 - For governance/enforcement/minimal-change/verification-only slices, honor the spec closeout contract: `surface_policy`, `minimum_valid_completion`, `validated_noop_allowed`, and `acceptable_evidence`.

--- a/OPENCODE.md
+++ b/OPENCODE.md
@@ -8,6 +8,7 @@ Use this file as the root operational contract when the assistant does not load 
 - `.flow/**` is operational state only.
 - Read the target spec and `workspace.config.json` before non-trivial edits.
 - Run workspace-managed commands from the devcontainer by default with `python3 ./flow workspace exec -- <cmd>` or `scripts/workspace_exec.sh <cmd>`.
+- `flow` invoked from host is blocked by default (`FLOW_FORCE_WORKSPACE_EXEC=1`) unless it is `flow stack ...` or explicit `flow workspace exec -- ...`.
 - Run repo runtime commands in the repo service with `python3 ./flow repo exec <repo> -- <cmd>`. Reserve `workspace exec` for workspace-managed tooling.
 - If the command must validate a materialized slice, prefer `python3 ./flow repo exec <repo> --workdir <worktree> -- <cmd>` so runtime resolution happens against that worktree.
 - For governance/enforcement/minimal-change/verification-only slices, use the spec closeout contract instead of guessing whether more surface work is needed.

--- a/flow
+++ b/flow
@@ -3164,6 +3164,11 @@ def _enforce_workspace_only(raw_args: list[str]) -> None:
         return
     if os.environ.get("FLOW_FORCE_WORKSPACE_EXEC", "1") != "1":
         return
+    if os.environ.get("FLOW_SKIP_WORKSPACE_DELEGATION") == "1":
+        return
+    if os.environ.get("GITHUB_ACTIONS", "").lower() == "true":
+        # GitHub-hosted runners execute `flow` on host by design.
+        return
     if not raw_args:
         return
 

--- a/flow
+++ b/flow
@@ -3152,9 +3152,33 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     require_dirs()
+    raw_args = sys.argv[1:]
+    _enforce_workspace_only(raw_args)
     parser = build_parser()
     args = parser.parse_args()
     return args.func(args)
+
+
+def _enforce_workspace_only(raw_args: list[str]) -> None:
+    if running_inside_workspace():
+        return
+    if os.environ.get("FLOW_FORCE_WORKSPACE_EXEC", "1") != "1":
+        return
+    if not raw_args:
+        return
+
+    top_level = raw_args[0]
+    if top_level == "stack":
+        # Stack lifecycle commands must run on host to create/recreate containers.
+        return
+    if top_level == "workspace" and len(raw_args) > 1 and raw_args[1] == "exec":
+        return
+
+    raise SystemExit(
+        "Host execution is blocked by FLOW_FORCE_WORKSPACE_EXEC=1. "
+        "Run commands via `python3 ./flow workspace exec -- python3 ./flow ...` "
+        "or `scripts/workspace_exec.sh python3 ./flow ...`."
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Block host-level flow commands by default and require workspace exec, keeping only stack/workspace-exec paths on host for container lifecycle operations.